### PR TITLE
enabling travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,5 @@
+language: node_js
+node_js:
+  - "9"
+  - "8"
+  - "7"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # React AAD MSAL
 
-![build status](https://reactaad.visualstudio.com/_apis/public/build/definitions/1c71aebc-1683-48cd-9ab2-8663e6a4ec55/5/badge)
+[![Build Status](https://travis-ci.org/Azure-Samples/react-aad-msal.svg?branch=master)](https://travis-ci.org/Azure-Samples/react-aad-msal)
 
 React AAD MSAL is a library to easily integrate the Microsoft Authentication Library with Azure Active Directory in your React app quickly and reliably.  The library focuses on flexibility, allowing you to define how you want to interact with logins and logouts.
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://reactaad.visualstudio.com/_git/react-aad-msal"
+    "url": "https://github.com/Azure-Samples/react-aad-msal.git"
   },
   "main": "dist/index.js",
   "files": [
@@ -101,7 +101,8 @@
   "keywords": [
     "Azure AD",
     "MSAL",
-    "React"
+    "React",
+    "OAuth"
   ],
   "jest": {
     "collectCoverageFrom": [

--- a/sample/package.json
+++ b/sample/package.json
@@ -6,7 +6,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://reactaad.visualstudio.com/_git/react-aad-msal-samples"
+    "url": "https://github.com/Azure-Samples/react-aad-msal.git"
   },
   "author": "Laura Bochenek",
   "contributors": [


### PR DESCRIPTION
Enables basic travis build using default options. Only builds, nothing else.

both PRs and merge requests.

closes #1 #7 