### PR TITLE
Need to force bump version to fix deploy

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-aad-msal",
-  "version": "0.3.15",
+  "version": "0.3.17",
   "description": "A react component that integrates with Azure AD (v2, MSAL).",
   "private": false,
   "license": "MIT",


### PR DESCRIPTION
Deploy won't work as we've deployed 3.15 "after" 3.16.