### PR TITLE
Refactor MSAL-specific configuration options into seperate prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Find the assignment for ClientID and replace the value with the Application ID f
       provider={new MsalAuthProviderFactory({
         clientID: '<Application ID for your application>',
         scopes: ['<property (i.e. user.read)>', 'https://<your-tenant-name>.onmicrosoft.com/<your-application-name>/<scope (i.e. demo.read)>'],
-        authority" 'https://login.microsoftonline.com/tfp/<your-tenant-name>.onmicrosoft.com/<your-sign-in-sign-up-policy>',
+        authority: 'https://login.microsoftonline.com/tfp/<your-tenant-name>.onmicrosoft.com/<your-sign-in-sign-up-policy>',
         type: LoginType.Popup,
         persistLoginPastSession: true
       })}

--- a/README.md
+++ b/README.md
@@ -49,15 +49,16 @@ Find the assignment for ClientID and replace the value with the Application ID f
 
   return (
     <AzureAD
-      clientID={'<Application ID for your application>'}
-      scopes={['<property (i.e. user.read)>', 'https://<your-tenant-name>.onmicrosoft.com/<your-application-name>/<scope (i.e. demo.read)>']}
+      provider={new MsalAuthProviderFactory({
+        clientID: '<Application ID for your application>',
+        scopes: ['<property (i.e. user.read)>', 'https://<your-tenant-name>.onmicrosoft.com/<your-application-name>/<scope (i.e. demo.read)>'],
+        authority" 'https://login.microsoftonline.com/tfp/<your-tenant-name>.onmicrosoft.com/<your-sign-in-sign-up-policy>',
+        type: LoginType.Popup,
+        persistLoginPastSession: true
+      })}
       unauthenticatedFunction={this.loginCallback}
       authenticatedFunction={this.logoutCallback}
-      userInfoCallback={this.printUserInfo}
-      authority={'https://login.microsoftonline.com/tfp/<your-tenant-name>.onmicrosoft.com/<your-sign-in-sign-up-policy>'}
-      type={LoginType.Popup}
-      persistLoginPastSession={true}>
-    </AzureAD>
+      userInfoCallback={this.printUserInfo} />
 );
 ```
 
@@ -65,14 +66,26 @@ Find the assignment for ClientID and replace the value with the Application ID f
 
 | Property | Description |
 | --- | --- |
-| `clientID` | String representing your Azure Active Directory Application ID |
-| `scopes` | Array of permission scopes you want to request from the application you are authenticating against. You can see possible [values for this property here](https://docs.microsoft.com/en-us/azure/active-directory/develop/active-directory-v2-scopes) |
+| `provider` | Factory object that provides the configuration values for your Azure Active Directory instance. See [Provider Options](#provider-options) in table below |
 | `authenticatedFunction` | A user defined callback function for the AzureAD component to consume. This function receives the AzureAD components `logout function` which you can use to trigger a logout |
 | `unauthenticatedFunction` | A user defined callback function for the AzureAD component to consume.  This function receives the AzureAD components `login function` which you can then use to trigger a login |
 | `userInfoCallback` | A user defined callback function for the AzureAD component to consume. The AzureAD component will call this function when login is complete to pass back the user info in the following format:  <br /><br /> ``` UserInfo { jwtAccessToken: string, jwtIdToken: string, user: Msal.User }```  <br /> <br /> The format of `Msal.User` [can be found here](https://htmlpreview.github.io/?https://raw.githubusercontent.com/AzureAD/microsoft-authentication-library-for-js/dev/docs/classes/_user_.user.html) |
+| `reduxStore` | **[Optional]** You can provide a redux store which the AzureAD component will dispatch `AAD_LOGIN_SUCCESS` and `AAD_LOGIN_SUCCESS` actions, as well as a `payload` containing `IUserInfo` |
+
+### Provider Options
+
+Each provider may have different configuration options. Depending on which provider you choose, you should use a different factory class.
+
+As of right now, there is only a single provider, but more may be added in future versions.
+
+#### MsalAuthProviderFactory
+
+| Property | Description |
+| --- | --- |
+| `clientID` | String representing your Azure Active Directory Application ID |
+| `scopes` | Array of permission scopes you want to request from the application you are authenticating against. You can see possible [values for this property here](https://docs.microsoft.com/en-us/azure/active-directory/develop/active-directory-v2-scopes) |
 | `authority` | **[Optional]** A string representing your Azure Active Directory application policy. Include if you are trying to authenticate against your Azure Active Directory application. If you're using a B2C AAD, it is usually in the format of: <br/> <br/> `https://login.microsoftonline.com/tfp/<your-tenant-name>.onmicrosoft.com/<your-sign-in-sign-up-policy>` |
 | `type` | **[Optional]** `LoginType.Popup` or `LoginType.Redirect`. Redirect is the default if this value is not provided. Make sure to import `LoginType` from the react-aad-msal npm module if using this property  |
-| `reduxStore` | **[Optional]** You can provide a redux store which the AzureAD component will dispatch `AAD_LOGIN_SUCCESS` and `AAD_LOGIN_SUCCESS` actions, as well as a `payload` containing `IUserInfo` |
 |`persistLoginPastSession`|**[Optional]** A boolean value representing if you want your user to be authenticated after the session ends. If `true` login information will be cached in `LocalStorage`. If `false` login information will be cached in `SessionStorage`. Defaults to `false`.|
 
 ## Login
@@ -124,13 +137,16 @@ Import your store into the file rendering the AzureAD component and pass it in:
 ``` jsx
 <AzureAD
   reduxStore={store}
-  clientID={'<Application ID for your application>'}
-  scopes={['<property (i.e. user.read)>', 'https://<your-tenant-name>.onmicrosoft.com/<your-application-name>/<scope (i.e. demo.read)>']}
+  provider={new MsalAuthProviderFactory({
+    clientID: '<Application ID for your application>',
+    scopes: ['<property (i.e. user.read)>', 'https://<your-tenant-name>.onmicrosoft.com/<your-application-name>/<scope (i.e. demo.read)>'],
+    authority: 'https://login.microsoftonline.com/tfp/<your-tenant-name>.onmicrosoft.com/<your-sign-in-sign-up-policy>',
+    type: LoginType.Popup,
+    persistLoginPastSession: true
+  })}
   unauthenticatedFunction={this.loginCallback}
   authenticatedFunction={this.logoutCallback}
   userInfoCallback={this.printUserInfo}
-  authority={'https://login.microsoftonline.com/tfp/<your-tenant-name>.onmicrosoft.com/<your-sign-in-sign-up-policy>'}
-  type={LoginType.Popup}
 />
 ```
 

--- a/sample/README.md
+++ b/sample/README.md
@@ -35,8 +35,8 @@ To run this sample, you just need to provide your `REACT_APP_AAD_APP_CLIENT_ID` 
 ``` jsx
 <AzureAD
   provider={new MsalAuthProviderFactory({
-            authority: process.env.REACT_APP_AUTHORITY,
             clientID: process.env.REACT_APP_AAD_APP_CLIENT_ID,
+            authority: process.env.REACT_APP_AUTHORITY,
   // ...
  >
 ```

--- a/sample/README.md
+++ b/sample/README.md
@@ -34,8 +34,9 @@ To run this sample, you just need to provide your `REACT_APP_AAD_APP_CLIENT_ID` 
 
 ``` jsx
 <AzureAD
-  clientID={process.env.REACT_APP_AAD_APP_CLIENT_ID}
-  authority={process.env.REACT_APP_AUTHORITY}
+  provider={new MsalAuthProviderFactory({
+            authority: process.env.REACT_APP_AUTHORITY,
+            clientID: process.env.REACT_APP_AAD_APP_CLIENT_ID,
   // ...
  >
 ```
@@ -47,7 +48,8 @@ Type is set to `LoginType.Popup`.
 ``` jsx
 <AzureAD
   // ...
-  type={LoginType.Popup}
+  provider={new MsalAuthProviderFactory({
+    type: LoginType.Popup
   // ...
 >
 ```
@@ -103,7 +105,8 @@ Type is set to `LoginType.Redirect`.
 ``` jsx
 <AzureAD
   // ...
-  type={LoginType.Redirect}
+  provider={new MsalAuthProviderFactory({
+    type: LoginType.Redirect
   // ...
 >
 ```

--- a/sample/src/SampleAppButtonLaunch.js
+++ b/sample/src/SampleAppButtonLaunch.js
@@ -24,7 +24,7 @@
 //
 
 import * as React from 'react';
-import { AzureAD, LoginType } from 'react-aad-msal';
+import { AzureAD, LoginType, MsalAuthProviderFactory } from 'react-aad-msal';
 import { basicReduxStore } from './reduxStore';
 
 class SampleAppButtonLaunch extends React.Component {
@@ -51,15 +51,17 @@ class SampleAppButtonLaunch extends React.Component {
     render() {
         return (
             <AzureAD
-                clientID={process.env.REACT_APP_AAD_APP_CLIENT_ID}
-                scopes={["openid"]}
-                authority={process.env.REACT_APP_AUTHORITY}
-                type={LoginType.Popup}
+                provider={new MsalAuthProviderFactory({
+                    authority: process.env.REACT_APP_AUTHORITY,
+                    clientID: process.env.REACT_APP_AAD_APP_CLIENT_ID,
+                    scopes: ["openid"],
+                    type: LoginType.Popup,
+                    persistLoginPastSession: true,
+                })}
                 unauthenticatedFunction={this.unauthenticatedFunction}
-                userInfoCallback={this.userJustLoggedIn}
                 reduxStore={basicReduxStore}
                 authenticatedFunction={this.authenticatedFunction}
-                persistLoginPastSession={true} />
+                userInfoCallback={this.userJustLoggedIn} />
         );
     }
 }

--- a/sample/src/SampleAppRedirectOnLaunch.js
+++ b/sample/src/SampleAppRedirectOnLaunch.js
@@ -24,7 +24,7 @@
 //
 
 import * as React from 'react';
-import { AzureAD, LoginType } from 'react-aad-msal';
+import { AzureAD, LoginType, MsalAuthProviderFactory } from 'react-aad-msal';
 
 class SampleAppRedirectOnLaunch extends React.Component {
   constructor(props) {
@@ -93,14 +93,16 @@ class SampleAppRedirectOnLaunch extends React.Component {
             <input type="checkbox" value={this.state.redirectEnabled} onChange={this.handleCheck} /> Enable redirect
           </div> : <div/>}
         <AzureAD
-          clientID={process.env.REACT_APP_AAD_APP_CLIENT_ID}
-          scopes={["openid"]}
-          authority={process.env.REACT_APP_AUTHORITY}
-          type={LoginType.Redirect}
+          provider={new MsalAuthProviderFactory({
+            authority: process.env.REACT_APP_AUTHORITY,
+            clientID: process.env.REACT_APP_AAD_APP_CLIENT_ID,
+            scopes: ["openid"],
+            type: LoginType.Redirect,
+            persistLoginPastSession: true,
+          })}
           unauthenticatedFunction={this.unauthenticatedFunction}
           userInfoCallback={this.userJustLoggedIn}
-          authenticatedFunction={this.authenticatedFunction}
-          persistLoginPastSession={true} />
+          authenticatedFunction={this.authenticatedFunction} />
       </div>
     );
   }

--- a/src/Interfaces.ts
+++ b/src/Interfaces.ts
@@ -46,7 +46,7 @@ interface IMsalAuthProviderConfig {
   authority?: string,
   persistLoginPastSession?: boolean,
   scopes: string[],
-  type: LoginType,
+  type?: LoginType,
 }
 
 interface IAuthProvider {

--- a/src/MsalAuthProvider.ts
+++ b/src/MsalAuthProvider.ts
@@ -35,6 +35,8 @@ const StorageLocations: {localStorage: string, sessionStorage: string}  = {
 }
 
 export abstract class MsalAuthProvider implements IAuthProvider {
+  public userInfoChangedCallback : (userInfo: IUserInfo) => void;
+
   protected clientApplication: Msal.UserAgentApplication;
   protected config: IMsalAuthProviderConfig;
   protected userInfo : IUserInfo;
@@ -96,8 +98,8 @@ export abstract class MsalAuthProvider implements IAuthProvider {
     };
 
     this.userInfo = user;
-    if (this.config.userInfoChangedCallback) {
-      this.config.userInfoChangedCallback(user);
+    if (this.userInfoChangedCallback) {
+      this.userInfoChangedCallback(user);
     }
   }
   

--- a/src/MsalAuthProviderFactory.ts
+++ b/src/MsalAuthProviderFactory.ts
@@ -22,39 +22,23 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
-import * as Msal from 'msal';
+import { IAuthProvider, IAuthProviderFactory, IMsalAuthProviderConfig, LoginType } from "./Interfaces";
+import { MsalPopupAuthProvider } from "./MsalPopupAuthProvider";
+import { MsalRedirectAuthProvider } from "./MsalRedirectAuthProvider";
 
-type UserInfoCallback = (token: IUserInfo) => void;
+export class MsalAuthProviderFactory implements IAuthProviderFactory {
+  private config : IMsalAuthProviderConfig;
 
-enum LoginType {
-  Popup,
-  Redirect,
-}
-
-interface IUserInfo {
-  jwtAccessToken: string,
-  jwtIdToken: string,
-  user: Msal.User,
-}
-
-interface IAuthProviderFactory {
-  getAuthProvider() : IAuthProvider
-}
-
-interface IMsalAuthProviderConfig {
-  clientID: string,
-  authority?: string,
-  persistLoginPastSession?: boolean,
-  scopes: string[],
-  type: LoginType,
-}
-
-interface IAuthProvider {
-  userInfoChangedCallback? : (userInfo: IUserInfo) => void,
+  constructor(config : IMsalAuthProviderConfig) {
+    this.config = config;
+  }
   
-  getUserInfo() : IUserInfo,
-  login() : void,
-  logout() : void,
+  public getAuthProvider(): IAuthProvider {
+    if (this.config.type === LoginType.Popup) {
+      return new MsalPopupAuthProvider(this.config);
+    }
+    else {
+      return new MsalRedirectAuthProvider(this.config);
+    }
+  }
 }
-
-export { IAuthProvider, IAuthProviderFactory, IMsalAuthProviderConfig, IUserInfo, LoginType, UserInfoCallback }

--- a/src/index.test.tsx
+++ b/src/index.test.tsx
@@ -33,6 +33,7 @@ require('jest-localstorage-mock'); // tslint:disable-line
 
 import { AuthenticationState, AzureAD, LoginType } from './index';
 import { IUserInfo } from './Interfaces';
+import { MsalAuthProviderFactory } from './MsalAuthProviderFactory';
 
 Enzyme.configure({ adapter: new Adapter() })
 
@@ -64,13 +65,15 @@ it('updates the userInfo state', () => {
 
   const wrapper = Enzyme.shallow(
     <AzureAD
-      clientID={'<random-guid>'}
-      scopes={['openid']}
+      provider={new MsalAuthProviderFactory({
+        authority: null,
+        clientID: '<random-guid>',
+        scopes: ['openid'],
+        type: LoginType.Popup,
+      })}
       unauthenticatedFunction={unauthenticatedFunction}
       authenticatedFunction={authenticatedFunction}
       userInfoCallback={userInfoCallback}
-      authority={null}
-      type={LoginType.Popup}
     />
   ).instance() as AzureAD;
 
@@ -112,13 +115,15 @@ it('logs out the user', () => {
 
   const wrapper = Enzyme.shallow(
     <AzureAD
-      clientID={'<random-guid>'}
-      scopes={['openid']}
+      provider={new MsalAuthProviderFactory({
+        authority: null,
+        clientID: '<random-guid>',
+        scopes: ['openid'],
+        type: LoginType.Popup,
+      })}
       unauthenticatedFunction={unauthenticatedFunction}
       authenticatedFunction={authenticatedFunction}
       userInfoCallback={userInfoCallback}
-      authority={null}
-      type={LoginType.Popup}
     />
   ).instance() as AzureAD;
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -25,15 +25,10 @@
 
 import * as React from 'react';
 import { Store } from 'redux';
-import { AAD_LOGIN_SUCCESS, AAD_LOGOUT_SUCCESS, loginSuccessful, logoutSuccessful } from './actions';
-import { IAuthProvider, IMsalAuthProviderConfig, IUserInfo, UserInfoCallback} from './Interfaces';
-import { MsalPopupAuthProvider } from './MsalPopupAuthProvider';
-import { MsalRedirectAuthProvider } from './MsalRedirectAuthProvider';
 
-enum LoginType {
-  Popup,
-  Redirect,
-}
+import { AAD_LOGIN_SUCCESS, AAD_LOGOUT_SUCCESS, loginSuccessful, logoutSuccessful } from './actions';
+import { IAuthProvider, IAuthProviderFactory, IUserInfo, LoginType, UserInfoCallback} from './Interfaces';
+import { MsalAuthProviderFactory } from './MsalAuthProviderFactory';
 
 enum AuthenticationState {
   Unauthenticated,
@@ -47,15 +42,11 @@ type LoginFunction = () => void;
 type LogoutFunction = () => void;
 
 interface IProps {
-  clientID: string,
-  scopes: string[],
+  provider : IAuthProviderFactory,
   unauthenticatedFunction: UnauthenticatedFunction,
   authenticatedFunction: AuthenticatedFunction,
   userInfoCallback: UserInfoCallback,
   reduxStore?: Store
-  authority?: string,
-  type?: LoginType,
-  persistLoginPastSession?: boolean
 }
 
 interface IState {
@@ -70,20 +61,8 @@ class AzureAD extends React.Component<IProps, IState> {
 
     const authenticationState = AuthenticationState.Unauthenticated;
 
-    const config : IMsalAuthProviderConfig = {
-      authority: props.authority,
-      clientID: props.clientID,
-      persistLoginPastSession: props.persistLoginPastSession,
-      scopes: props.scopes,
-      userInfoChangedCallback: this.updateState
-    };
-    
-    if (this.props.type === LoginType.Popup) {
-      this.authProvider = new MsalPopupAuthProvider(config);
-    }
-    else {
-      this.authProvider = new MsalRedirectAuthProvider(config);
-    }
+    this.authProvider = this.props.provider.getAuthProvider();
+    this.authProvider.userInfoChangedCallback = this.updateState;
 
     this.state = { authenticationState };
   }
@@ -152,5 +131,5 @@ class AzureAD extends React.Component<IProps, IState> {
   }
 }
 
-export { AzureAD, AAD_LOGIN_SUCCESS, AAD_LOGOUT_SUCCESS, AuthenticationState, LoginType };
+export { AzureAD, AAD_LOGIN_SUCCESS, AAD_LOGOUT_SUCCESS, AuthenticationState, LoginType, MsalAuthProviderFactory };
 export default AzureAD;


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* This PR breaks the last bit of coupling between the AzureAD component and the MSAL libraries. Now, any implementation of IAuthProvider will work with the component, and there are no references to MSAL in the component itself. Also, IAuthProvider objects can now be passed in via props to the AzureAD component, which opens it up for unit testing (coming soon!)

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[x] Yes
[ ] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## Other Information
Let me know what everyone thinks about the new JSX format (you can see it in action in the samples, test code, or README). It does add an additional class that is required, but I think this makes it easiest for us to test as well as the easiest way to break out the MSAL code. Definitely open to suggestions though! Also if the name "provider" is confusing I can change that as well.