### PR TITLE
Added option for redirctUri to authProvider

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ Find the assignment for ClientID and replace the value with the Application ID f
         clientID: '<Application ID for your application>',
         scopes: ['<property (i.e. user.read)>', 'https://<your-tenant-name>.onmicrosoft.com/<your-application-name>/<scope (i.e. demo.read)>'],
         authority: 'https://login.microsoftonline.com/tfp/<your-tenant-name>.onmicrosoft.com/<your-sign-in-sign-up-policy>',
+        redirectUri: '<Optional redirect URI for your application>'
         type: LoginType.Popup,
         persistLoginPastSession: true
       })}
@@ -85,6 +86,7 @@ As of right now, there is only a single provider, but more may be added in futur
 | `clientID` | String representing your Azure Active Directory Application ID |
 | `scopes` | Array of permission scopes you want to request from the application you are authenticating against. You can see possible [values for this property here](https://docs.microsoft.com/en-us/azure/active-directory/develop/active-directory-v2-scopes) |
 | `authority` | **[Optional]** A string representing your Azure Active Directory application policy. Include if you are trying to authenticate against your Azure Active Directory application. If you're using a B2C AAD, it is usually in the format of: <br/> <br/> `https://login.microsoftonline.com/tfp/<your-tenant-name>.onmicrosoft.com/<your-sign-in-sign-up-policy>` |
+| `redirectUri` | **[Optional]** String representing the URI to redirect back to when authentication completes |
 | `type` | **[Optional]** `LoginType.Popup` or `LoginType.Redirect`. Redirect is the default if this value is not provided. Make sure to import `LoginType` from the react-aad-msal npm module if using this property  |
 |`persistLoginPastSession`|**[Optional]** A boolean value representing if you want your user to be authenticated after the session ends. If `true` login information will be cached in `LocalStorage`. If `false` login information will be cached in `SessionStorage`. Defaults to `false`.|
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Find the assignment for ClientID and replace the value with the Application ID f
         clientID: '<Application ID for your application>',
         scopes: ['<property (i.e. user.read)>', 'https://<your-tenant-name>.onmicrosoft.com/<your-application-name>/<scope (i.e. demo.read)>'],
         authority: 'https://login.microsoftonline.com/tfp/<your-tenant-name>.onmicrosoft.com/<your-sign-in-sign-up-policy>',
-        redirectUri: '<Optional redirect URI for your application>'
+        redirectUri: '<Optional redirect URI for your application>',
         type: LoginType.Popup,
         persistLoginPastSession: true
       })}

--- a/src/Interfaces.ts
+++ b/src/Interfaces.ts
@@ -47,6 +47,7 @@ interface IMsalAuthProviderConfig {
   persistLoginPastSession?: boolean,
   scopes: string[],
   type?: LoginType,
+  redirectUri?: string
 }
 
 interface IAuthProvider {

--- a/src/MsalAuthProvider.ts
+++ b/src/MsalAuthProvider.ts
@@ -49,7 +49,8 @@ export abstract class MsalAuthProvider implements IAuthProvider {
       authProviderConfig.authority ? authProviderConfig.authority : null,
       this.tokenRedirectCallback,
       {
-        cacheLocation: authProviderConfig.persistLoginPastSession ? StorageLocations.localStorage : StorageLocations.sessionStorage
+        cacheLocation: authProviderConfig.persistLoginPastSession ? StorageLocations.localStorage : StorageLocations.sessionStorage,
+        redirectUri: authProviderConfig.redirectUri
       }
     );
   }


### PR DESCRIPTION
## Purpose
Adds an option to specify the redirect URI when configuring the auth provider, which is passed through to the same option in the MSAL UserAgentApplication.

## Does this introduce a breaking change?
[ ] Yes
[x] No

## Pull Request Type
What kind of change does this Pull Request introduce?

[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:

## How to Test
*  Fetch and build the code

git clone -b issue/55/redirecturi https://github.com/abrunyee/react-aad-msal.git
cd ./react-aad-msal
npm install
npm run build

* Reference this code in your test project, e.g. npm install -s ../local_modules/react-aad-msal if the repository was built in a 'local_modules' directory.

## What to Check
Verify that the following are valid
* Specifying the redirectUri correctly passes the value through to the MSAL ClientUserAgent
* Not specifying the redirectUri results in the default behaviour and does not break existing code

## Other Information
This addresses the issue covered by #55 